### PR TITLE
Add dragon passenger layer

### DIFF
--- a/src/main/java/dmr/DragonMounts/DragonMountsRemaster.java
+++ b/src/main/java/dmr/DragonMounts/DragonMountsRemaster.java
@@ -1,21 +1,22 @@
 package dmr.DragonMounts;
 
-import com.google.common.graph.Network;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.mojang.brigadier.CommandDispatcher;
-import dmr.DragonMounts.registry.*;
-import dmr.DragonMounts.server.events.LootTableInject;
-import dmr.DragonMounts.types.abilities.types.Ability;
 import dmr.DragonMounts.client.gui.DragonInventoryScreen;
 import dmr.DragonMounts.client.model.DragonEggModelLoader;
+import dmr.DragonMounts.client.renderer.layers.DragonPassengerLayer;
 import dmr.DragonMounts.common.config.DMRConfig;
-import dmr.DragonMounts.types.dragonBreeds.DataPackLoader;
+import dmr.DragonMounts.network.NetworkHandler;
+import dmr.DragonMounts.registry.*;
+import dmr.DragonMounts.server.entity.DMRDragonEntity;
+import dmr.DragonMounts.server.events.LootTableInject;
 import dmr.DragonMounts.server.items.DragonSpawnEgg;
+import dmr.DragonMounts.types.abilities.types.Ability;
+import dmr.DragonMounts.types.dragonBreeds.DataPackLoader;
 import dmr.DragonMounts.types.dragonBreeds.ResourcePackLoader;
 import dmr.DragonMounts.types.habitats.Habitat;
-import dmr.DragonMounts.network.NetworkHandler;
 import dmr.DragonMounts.util.type_adapters.*;
 import lombok.Getter;
 import net.minecraft.client.gui.screens.MenuScreens;
@@ -23,6 +24,7 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.Item;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
@@ -37,8 +39,10 @@ import net.neoforged.fml.loading.FMLLoader;
 import net.neoforged.neoforge.client.event.ModelEvent;
 import net.neoforged.neoforge.client.event.RegisterColorHandlersEvent;
 import net.neoforged.neoforge.client.event.RegisterColorHandlersEvent.Block;
+import net.neoforged.neoforge.client.event.RenderLivingEvent;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
+
 import java.util.List;
 
 @Mod(DragonMountsRemaster.MOD_ID )
@@ -90,6 +94,7 @@ public class DragonMountsRemaster
 		{
 			bus.addListener((ModelEvent.RegisterGeometryLoaders e) -> e.register(id("dragon_egg"), DragonEggModelLoader.INSTANCE));
 			bus.addListener((RegisterColorHandlersEvent.Item e) -> e.register(DragonSpawnEgg::getColor, DMRItems.DRAGON_SPAWN_EGG.get()));
+			NeoForge.EVENT_BUS.addListener(this::cancelPassengerRenderEvent);
 		}
 
 		bus.addListener(DataPackLoader::newDataPack);
@@ -116,5 +121,17 @@ public class DragonMountsRemaster
 	@SubscribeEvent
 	public void serverRegisterCommandsEvent(RegisterCommandsEvent event){
 		CommandDispatcher<CommandSourceStack> commandDispatcher = event.getDispatcher();
+	}
+
+	//@SubscribeEvent
+	//public <T extends LivingEntity, M extends EntityModel<T>> void cancelPassengerRenderEvent(RenderLivingEvent.Pre<T, M> event){
+	//	LivingEntity entity = event.getEntity();
+	//	if (entity.getVehicle() instanceof DMRDragonEntity && DragonPassengerLayer.passengers.contains(entity.getUUID())) event.setCanceled(true);
+	//}
+
+	@SubscribeEvent
+	public void cancelPassengerRenderEvent(RenderLivingEvent.Pre event){
+		LivingEntity entity = event.getEntity();
+		if (entity.getVehicle() instanceof DMRDragonEntity && DragonPassengerLayer.passengers.contains(entity.getUUID())) event.setCanceled(true);
 	}
 }

--- a/src/main/java/dmr/DragonMounts/DragonMountsRemaster.java
+++ b/src/main/java/dmr/DragonMounts/DragonMountsRemaster.java
@@ -123,12 +123,6 @@ public class DragonMountsRemaster
 		CommandDispatcher<CommandSourceStack> commandDispatcher = event.getDispatcher();
 	}
 
-	//@SubscribeEvent
-	//public <T extends LivingEntity, M extends EntityModel<T>> void cancelPassengerRenderEvent(RenderLivingEvent.Pre<T, M> event){
-	//	LivingEntity entity = event.getEntity();
-	//	if (entity.getVehicle() instanceof DMRDragonEntity && DragonPassengerLayer.passengers.contains(entity.getUUID())) event.setCanceled(true);
-	//}
-
 	@SubscribeEvent
 	public void cancelPassengerRenderEvent(RenderLivingEvent.Pre event){
 		LivingEntity entity = event.getEntity();

--- a/src/main/java/dmr/DragonMounts/client/renderer/DragonRenderer.java
+++ b/src/main/java/dmr/DragonMounts/client/renderer/DragonRenderer.java
@@ -4,6 +4,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import dmr.DragonMounts.DragonMountsRemaster;
 import dmr.DragonMounts.client.renderer.layers.DragonGlowLayer;
+import dmr.DragonMounts.client.renderer.layers.DragonPassengerLayer;
 import dmr.DragonMounts.client.renderer.layers.DragonSaddleLayer;
 import dmr.DragonMounts.server.entity.DMRDragonEntity;
 import dmr.DragonMounts.types.dragonBreeds.ResourcePackLoader;
@@ -28,6 +29,7 @@ public class DragonRenderer extends GeoEntityRenderer<DMRDragonEntity>
 		super(renderManager, modelProvider);
 		renderLayers.addLayer(new DragonGlowLayer(this));
 		renderLayers.addLayer(new DragonSaddleLayer(this));
+		renderLayers.addLayer(new DragonPassengerLayer<>(this, "rider"));
 	}
 	
 	@Override

--- a/src/main/java/dmr/DragonMounts/client/renderer/layers/DragonPassengerLayer.java
+++ b/src/main/java/dmr/DragonMounts/client/renderer/layers/DragonPassengerLayer.java
@@ -1,0 +1,79 @@
+package dmr.DragonMounts.client.renderer.layers;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.math.Axis;
+import dmr.DragonMounts.server.entity.DMRDragonEntity;
+import net.minecraft.CrashReport;
+import net.minecraft.ReportedException;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
+import net.minecraft.client.renderer.entity.EntityRenderer;
+import net.minecraft.world.entity.Entity;
+import software.bernie.geckolib.cache.object.GeoBone;
+import software.bernie.geckolib.renderer.GeoRenderer;
+import software.bernie.geckolib.renderer.layer.GeoRenderLayer;
+import software.bernie.geckolib.util.RenderUtils;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public class DragonPassengerLayer<T extends DMRDragonEntity> extends GeoRenderLayer<T> {
+    private final String passengerBone;
+    private final int passengerNumber;
+    public static Set<UUID> passengers = new HashSet<>();
+
+    public DragonPassengerLayer(GeoRenderer<T> entityRendererIn, String passengerBone, int passengerNumber) {
+        super(entityRendererIn);
+        this.passengerBone = passengerBone;
+        this.passengerNumber = passengerNumber;
+    }
+
+    public DragonPassengerLayer(GeoRenderer<T> entityRendererIn, String passengerBone) {
+        this(entityRendererIn, passengerBone, 0);
+    }
+
+    @Override
+    public void renderForBone(PoseStack matrixStackIn, T entity, GeoBone bone, RenderType renderType,
+                              MultiBufferSource bufferSource, VertexConsumer buffer, float partialTick, int packedLight, int packedOverlay) {
+        if (!bone.getName().equals(passengerBone)) return;
+
+        Entity passenger = entity.getPassengers().size() > passengerNumber ? entity.getPassengers().get(passengerNumber) : null;
+        if (passenger != null) {
+            matrixStackIn.pushPose();
+            passengers.remove(passenger.getUUID());
+
+            matrixStackIn.translate(0, -0.7f, 0);
+            RenderUtils.translateToPivotPoint(matrixStackIn, bone);
+                matrixStackIn.mulPose(Axis.YP.rotationDegrees(entity.getViewYRot(partialTick) - 180));
+            renderEntity(passenger, partialTick, matrixStackIn, bufferSource, packedLight);
+            buffer = bufferSource.getBuffer(renderType);
+
+            passengers.add(passenger.getUUID());
+            matrixStackIn.popPose();
+        }
+    }
+
+
+    public <E extends Entity> void renderEntity(E entityIn, float partialTicks, PoseStack matrixStack, MultiBufferSource bufferIn, int packedLight) {
+        boolean isFirstPerson = Minecraft.getInstance().options.getCameraType().isFirstPerson();
+        LocalPlayer clientPlayer = Minecraft.getInstance().player;
+        if (isFirstPerson && entityIn == clientPlayer) return;
+
+        EntityRenderer<? super E> render;
+        EntityRenderDispatcher manager = Minecraft.getInstance().getEntityRenderDispatcher();
+
+        render = manager.getRenderer(entityIn);
+        matrixStack.pushPose();
+        try {
+            render.render(entityIn, 0, partialTicks, matrixStack, bufferIn, packedLight);
+        } catch (Throwable throwable1) {
+            throw new ReportedException(CrashReport.forThrowable(throwable1, "Rendering entity in world"));
+        }
+        matrixStack.popPose();
+    }
+}

--- a/src/main/java/dmr/DragonMounts/client/renderer/layers/DragonPassengerLayer.java
+++ b/src/main/java/dmr/DragonMounts/client/renderer/layers/DragonPassengerLayer.java
@@ -49,7 +49,7 @@ public class DragonPassengerLayer<T extends DMRDragonEntity> extends GeoRenderLa
 
             matrixStackIn.translate(0, -0.7f, 0);
             RenderUtils.translateToPivotPoint(matrixStackIn, bone);
-                matrixStackIn.mulPose(Axis.YP.rotationDegrees(entity.getViewYRot(partialTick) - 180));
+                matrixStackIn.mulPose(Axis.YP.rotationDegrees(entity.getYRot() - 180));
             renderEntity(passenger, partialTick, matrixStackIn, bufferSource, packedLight);
             buffer = bufferSource.getBuffer(renderType);
 

--- a/src/main/resources/assets/dmr/geo/dragon.geo.json
+++ b/src/main/resources/assets/dmr/geo/dragon.geo.json
@@ -2174,9 +2174,9 @@
 					]
 				},
 				{
-					"name": "bone",
+					"name": "rider",
 					"parent": "body",
-					"pivot": [0, 43.5, -20]
+					"pivot": [0, 43.5, -18]
 				}
 			]
 		}


### PR DESCRIPTION
DragonPassengerLayer allows to specify bone relative to which passenger will be rendered. In this case, it's used to specify position of rider's model.

Pros of used approach:
- Passenger model is independent from actual passenger position
- Passenger model follows exact movement of the model, which puts less restrictions on the animations
- Passenger model position can be adjusted via animations
- Only thing that is needed to be specified is bone name 
- Can be used for specifying model position of other passengers of the dragon

Cons:
- Bone name needs to be hardcoded (currently "rider" for controlling passenger, maybe there can be found workaround with this custom breeds system)
- Specified bone must be presented on the model to avoid rendering issues (no check for if model even has this bone is implemented)

Example with custom model:
![image](https://github.com/Wyrmheart-Team/Dragon_Mounts_Remastered/assets/73118477/ce6ef85d-c29e-4400-9bcc-e935ff74b6c1)
![ezgif-5-fcefc9d88b](https://github.com/Wyrmheart-Team/Dragon_Mounts_Remastered/assets/73118477/85026d3f-54d9-4a40-a58c-63da5620a525)

