### PR TITLE
Potential fix for code scanning alert no. 14: Uncontrolled data in arithmetic expression

### DIFF
--- a/src/main/java/dmr/DragonMounts/server/entity/dragon/DragonAttributeComponent.java
+++ b/src/main/java/dmr/DragonMounts/server/entity/dragon/DragonAttributeComponent.java
@@ -194,6 +194,9 @@ abstract class DragonAttributeComponent extends DragonSpawnComponent {
         if (upper < lower) {
             throw new IllegalArgumentException("Upper bound must be greater than or equal to lower bound.");
         }
+        if (lower < Integer.MIN_VALUE || upper > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Bounds must be within the valid range for integers.");
+        }
         double result = (value * ((double) upper - (double) lower)) + (double) lower;
         if (result > Integer.MAX_VALUE || result < Integer.MIN_VALUE) {
             throw new ArithmeticException("Result exceeds valid range for integers.");

--- a/src/main/java/dmr/DragonMounts/server/entity/dragon/DragonAttributeComponent.java
+++ b/src/main/java/dmr/DragonMounts/server/entity/dragon/DragonAttributeComponent.java
@@ -191,7 +191,14 @@ abstract class DragonAttributeComponent extends DragonSpawnComponent {
     }
 
     private int upperLower(double value, int lower, int upper) {
-        return (int) Math.round((value * ((double) upper - (double) lower)) + (double) lower);
+        if (upper < lower) {
+            throw new IllegalArgumentException("Upper bound must be greater than or equal to lower bound.");
+        }
+        double result = (value * ((double) upper - (double) lower)) + (double) lower;
+        if (result > Integer.MAX_VALUE || result < Integer.MIN_VALUE) {
+            throw new ArithmeticException("Result exceeds valid range for integers.");
+        }
+        return (int) Math.round(result);
     }
 
     private double randomUpperLower(int lower, int upper) {


### PR DESCRIPTION
Potential fix for [https://github.com/Wyrmheart-Team/Dragon_Mounts_Remastered/security/code-scanning/14](https://github.com/Wyrmheart-Team/Dragon_Mounts_Remastered/security/code-scanning/14)

To address the issue, we need to validate the inputs (`lower` and `upper`) and ensure that the arithmetic expression does not result in underflow or overflow. Specifically:
1. Add a guard to ensure that `upper` is greater than or equal to `lower`. If this condition is violated, the calculation should not proceed.
2. Ensure that the result of the arithmetic expression is within the valid range for an integer before casting.

The fix involves modifying the `upperLower` method on line 193 to include these safeguards.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
