### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -1,5 +1,10 @@
 name: Run semantic release
 
+permissions:
+  contents: read
+  issues: write
+  packages: write
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Wyrmheart-Team/Dragon_Mounts_Remastered/security/code-scanning/9](https://github.com/Wyrmheart-Team/Dragon_Mounts_Remastered/security/code-scanning/9)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's functionality, it likely needs read access to repository contents and write access to pull requests or releases.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `semantic-release` job to limit permissions specifically for that job. Since the `semantic-release` job is the only job in this workflow, adding the `permissions` block at the root level is sufficient.

The following permissions are recommended:
- `contents: read` for reading repository contents.
- `issues: write` or `pull-requests: write` if the workflow interacts with issues or pull requests.
- `packages: write` if the workflow publishes packages.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
